### PR TITLE
Insert trailing colons to avoid cursor jumps

### DIFF
--- a/wakeonlan/src/main/java/com/github/shingyx/wakeonlan/ui/MacAddressTextWatcher.kt
+++ b/wakeonlan/src/main/java/com/github/shingyx/wakeonlan/ui/MacAddressTextWatcher.kt
@@ -23,18 +23,26 @@ class MacAddressTextWatcher : TextWatcher {
     private fun formatMacAddress(text: String): String {
         val builder = StringBuilder()
         var digits = 0
+        var lastColonRequired = false
         for (char in text) {
             if (char.isLetterOrDigit()) {
-                if (digits % 2 == 0 && digits > 0 && digits < 12) {
+                if (builder.lastOrNull() != ':' && allowSeparator(digits)) {
                     builder.append(':')
+                    lastColonRequired = false
                 }
                 builder.append(char)
                 digits++
+            } else if (char == ':') {
+                lastColonRequired = true
             }
         }
-        if (text.lastOrNull() == ':') {
+        if ((lastColonRequired || text.lastOrNull() == ':') && allowSeparator(digits)) {
             builder.append(':')
         }
         return builder.toString()
+    }
+
+    private fun allowSeparator(digits: Int): Boolean {
+        return digits % 2 == 0 && digits in 1 until 12
     }
 }

--- a/wakeonlan/src/main/java/com/github/shingyx/wakeonlan/ui/MacAddressTextWatcher.kt
+++ b/wakeonlan/src/main/java/com/github/shingyx/wakeonlan/ui/MacAddressTextWatcher.kt
@@ -26,7 +26,7 @@ class MacAddressTextWatcher : TextWatcher {
         var lastColonRequired = false
         for (char in text) {
             if (char.isLetterOrDigit()) {
-                if (builder.lastOrNull() != ':' && allowSeparator(digits)) {
+                if (allowSeparator(digits)) {
                     builder.append(':')
                     lastColonRequired = false
                 }

--- a/wakeonlan/src/main/java/com/github/shingyx/wakeonlan/ui/MacAddressTextWatcher.kt
+++ b/wakeonlan/src/main/java/com/github/shingyx/wakeonlan/ui/MacAddressTextWatcher.kt
@@ -23,20 +23,20 @@ class MacAddressTextWatcher : TextWatcher {
     private fun formatMacAddress(text: String): String {
         val builder = StringBuilder()
         var digits = 0
-        var lastColonRequired = false
+        var insertTrailingColon = false
         for (char in text) {
             if (char.isLetterOrDigit()) {
                 if (allowSeparator(digits)) {
                     builder.append(':')
-                    lastColonRequired = false
+                    insertTrailingColon = false
                 }
                 builder.append(char)
                 digits++
             } else if (char == ':') {
-                lastColonRequired = true
+                insertTrailingColon = true
             }
         }
-        if ((lastColonRequired || text.lastOrNull() == ':') && allowSeparator(digits)) {
+        if ((insertTrailingColon || text.lastOrNull() == ':') && allowSeparator(digits)) {
             builder.append(':')
         }
         return builder.toString()


### PR DESCRIPTION
Avoids the cursor from jumping to the start in this scenario:
```
text before:
12:3
  |

press backspace:
1:3
 |

after formatting:
13:
 |


* after formatting, previous behaviour:
13
|
```

...but cursor can now jump when there's a trailing `:`, but this is less likely so 🤷 